### PR TITLE
Add the rest of currencies supported by API

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,10 @@
-import { SimplifiedCurrencyData } from './types'
+import { SimplifiedCurrencyData } from './types';
 
 const API_PATH = {
-  'GET_CURRENCY_RATES': 'https://api.exchangeratesapi.io/latest'
-}
+  GET_CURRENCY_RATES: 'https://api.exchangeratesapi.io/latest',
+};
 
-const FORMAT_NUMERAL = '0,0.000000'
+const FORMAT_NUMERAL = '0,0.000000';
 
 const CURRENCY_LIST: SimplifiedCurrencyData[] = [
   {
@@ -57,10 +57,116 @@ const CURRENCY_LIST: SimplifiedCurrencyData[] = [
     label: 'South Korean won',
     flagCode: 'kr',
   },
-]
+  {
+    currency: 'BGN',
+    label: 'Bulgarian le',
+    flagCode: 'bg',
+  },
+  {
+    currency: 'CZK',
+    label: 'Czech korun',
+    flagCode: 'cz',
+  },
+  {
+    currency: 'DKK',
+    label: 'Danish krone',
+    flagCode: 'dk',
+  },
+  {
+    currency: 'HUF',
+    label: 'Hungarian forint',
+    flagCode: 'hu',
+  },
+  {
+    currency: 'PLN',
+    label: 'Polish zloty',
+    flagCode: 'pl',
+  },
+  {
+    currency: 'RON',
+    label: 'Romanian leu',
+    flagCode: 'ro',
+  },
+  {
+    currency: 'SEK',
+    label: 'Swedish krona',
+    flagCode: 'se',
+  },
+  {
+    currency: 'ISK',
+    label: 'Icelandic krona',
+    flagCode: 'is',
+  },
+  {
+    currency: 'NOK',
+    label: 'Norwegian krone',
+    flagCode: 'no',
+  },
+  {
+    currency: 'HRK',
+    label: 'Croatian kun',
+    flagCode: 'hr',
+  },
+  {
+    currency: 'RUB',
+    label: 'Russian rouble',
+    flagCode: 'ru',
+  },
+  {
+    currency: 'TRY',
+    label: 'Turkish lira',
+    flagCode: 'tr',
+  },
+  {
+    currency: 'AUD',
+    label: 'Australian dollar',
+    flagCode: 'au',
+  },
+  {
+    currency: 'BRL',
+    label: 'Brazilian real',
+    flagCode: 'br',
+  },
+  {
+    currency: 'CNY',
+    label: 'Chinese yuan renminb',
+    flagCode: 'cn',
+  },
+  {
+    currency: 'HKD',
+    label: 'Hong Kong dollar',
+    flagCode: 'hk',
+  },
+  {
+    currency: 'ILS',
+    label: 'Israeli sheke',
+    flagCode: 'il',
+  },
+  {
+    currency: 'MXN',
+    label: 'Mexican pes',
+    flagCode: 'mx',
+  },
+  {
+    currency: 'NZD',
+    label: 'New Zealand dollar',
+    flagCode: 'nz',
+  },
+  {
+    currency: 'PHP',
+    label: 'Philippine pes',
+    flagCode: 'ph',
+  },
+  {
+    currency: 'THB',
+    label: 'Thai bah',
+    flagCode: 'th',
+  },
+  {
+    currency: 'ZAR',
+    label: 'South African rand',
+    flagCode: 'za',
+  },
+];
 
-export {
-  API_PATH,
-  CURRENCY_LIST,
-  FORMAT_NUMERAL
-}
+export { API_PATH, CURRENCY_LIST, FORMAT_NUMERAL };


### PR DESCRIPTION
I added the remaining currencies supported by the API (https://exchangeratesapi.io/). This addresses the issue Add more currency #7

The file was fixed by es-lint, hence the formatting changes that are not part of the CURRENCY_LIST array. If those are undesired we can of course undo them.